### PR TITLE
CON-214: Test for creating Connector with participant_qos

### DIFF
--- a/test/nodejs/test_rticonnextdds_connector.js
+++ b/test/nodejs/test_rticonnextdds_connector.js
@@ -92,6 +92,15 @@ describe('Connector Tests', function () {
       connector.close()
   })
 
+  it('Should be possible to create a Connector with participant qos', function () {
+      const xmlProfile = path.join(__dirname, '/../xml/TestConnector.xml')
+      const connector = new rti.Connector(
+           'MyParticipantLibrary::ConnectorWithParticipantQos',
+           xmlProfile)
+      expect(connector).to.exist
+      expect(connector).to.be.instanceOf(rti.Connector)
+  })
+
   describe('Connector callback test', function () {
     let connector
 

--- a/test/xml/TestConnector.xml
+++ b/test/xml/TestConnector.xml
@@ -306,5 +306,11 @@ This code contains trade secrets of Real-Time Innovations, Inc.
                 <data_writer name="TestWriter" topic_ref="SingleUseShape" />
             </publisher>
         </domain_participant>
+
+        <!-- Test for CON-214 -->
+        <domain_participant name="ConnectorWithParticipantQos"
+                            domain_ref="MyDomainLibrary::MyDomain">
+            <participant_qos/>
+        </domain_participant>
     </domain_participant_library>
 </dds>


### PR DESCRIPTION
@alexcamposruiz Confirmed that this test currently fails. Tested it with a librtiddsconnectord.so from develop (containing some initial changes in a feature branch to address this bug) and it passes.