### PR TITLE
Feature/con 173 napi

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ The `examples/nodejs` directory provides several examples:
 ## Dependencies
 
 RTI Connector for JavaScript has the following dependencies, which are also listed in `package.json`:
-* [ref](https://www.npmjs.com/package/ref): turns Buffer instances into "pointers"
-* [ffi](https://www.npmjs.com/package/ffi): used for loading and calling dynamic libraries using pure JavaScript
+* [ref-napi](https://www.npmjs.com/package/ref-napi): turns Buffer instances into "pointers"
+* [ref-struct-napi](https://www.npmjs.com/package/ref-struct-napi): create ABI-compilant "Struct" instances on top of Buffers
+* [ffi-napi](https://www.npmjs.com/package/ffi-napi): used for loading and calling dynamic libraries using pure JavaScript
 * [events](https://www.npmjs.com/package/events): used for the 'EventEmitter' (legacy implementation of RTI Connector)
 
 Additionally to run the `web_socket` example, [socket.io](https://github.com/Automattic/socket.io) and [OpenLayers](https://openlayers.org) are required.

--- a/README.rst
+++ b/README.rst
@@ -33,18 +33,19 @@ Dependencies
 ------------
 
 RTI Connector for JavaScript has the following dependencies, which are
-also listed in ``package.json``: \*
-`ref-napi <https://www.npmjs.com/package/ref-napi>`__: turns Buffer instances into
-“pointers” \* `ref-struct-napi <https://www.npmjs.com/package/ref-struct-napi>`__:
-create ABI-compilant "Struct" instances on top of Buffers /*
-`ffi-napi <https://www.npmjs.com/package/ffi-napi>`__: used for
-loading and calling dynamic libraries using pure JavaScript \*
-`events <https://www.npmjs.com/package/events>`__: used for the
+also listed in ``package.json``:
+-  `ref-napi <https://www.npmjs.com/package/ref-napi>`__: turns Buffer instances into
+“pointers”
+-  `ref-struct-napi <https://www.npmjs.com/package/ref-struct-napi>`__:
+create ABI-compilant "Struct" instances on top of Buffers
+-  `ffi-napi <https://www.npmjs.com/package/ffi-napi>`__: used for
+loading and calling dynamic libraries using pure JavaScript
+-  `events <https://www.npmjs.com/package/events>`__: used for the
 ‘EventEmitter’ (legacy implementation of RTI Connector)
 
 Additionally to run the ``web_socket`` example,
 `socket.io <https://github.com/Automattic/socket.io>`__ and
-[OpenLayers](hhttps://openlayers.org] are required.
+[OpenLayers](https://openlayers.org] are required.
 
 Additional dependencies are required to run the unit tests and some of
 the examples. Please see the README files in the appropriate directory.

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,10 @@ Dependencies
 
 RTI Connector for JavaScript has the following dependencies, which are
 also listed in ``package.json``: \*
-`ref <https://www.npmjs.com/package/ref>`__: turns Buffer instances into
-“pointers” \* `ffi <https://www.npmjs.com/package/ffi>`__: used for
+`ref-napi <https://www.npmjs.com/package/ref-napi>`__: turns Buffer instances into
+“pointers” \* `ref-struct-napi <https://www.npmjs.com/package/ref-struct-napi>`__:
+create ABI-compilant "Struct" instances on top of Buffers /*
+`ffi-napi <https://www.npmjs.com/package/ffi-napi>`__: used for
 loading and calling dynamic libraries using pure JavaScript \*
 `events <https://www.npmjs.com/package/events>`__: used for the
 ‘EventEmitter’ (legacy implementation of RTI Connector)

--- a/README.rst
+++ b/README.rst
@@ -34,14 +34,15 @@ Dependencies
 
 RTI Connector for JavaScript has the following dependencies, which are
 also listed in ``package.json``:
+
 -  `ref-napi <https://www.npmjs.com/package/ref-napi>`__: turns Buffer instances into
-“pointers”
+   “pointers”
 -  `ref-struct-napi <https://www.npmjs.com/package/ref-struct-napi>`__:
-create ABI-compilant "Struct" instances on top of Buffers
+   create ABI-compilant "Struct" instances on top of Buffers
 -  `ffi-napi <https://www.npmjs.com/package/ffi-napi>`__: used for
-loading and calling dynamic libraries using pure JavaScript
+   loading and calling dynamic libraries using pure JavaScript
 -  `events <https://www.npmjs.com/package/events>`__: used for the
-‘EventEmitter’ (legacy implementation of RTI Connector)
+   ‘EventEmitter’ (legacy implementation of RTI Connector)
 
 Additionally to run the ``web_socket`` example,
 `socket.io <https://github.com/Automattic/socket.io>`__ and

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   },
   "dependencies": {
     "events": "*",
-    "ffi": "github:rticommunity/node-ffi#node-12",
-    "ref": "github:rticommunity/ref#node-12",
+    "ref-napi": "*",
+    "ref-struct-napi": "*",
+    "ffi-napi": "*",
     "sleep": "*"
   },
   "keywords": [

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -7,10 +7,10 @@
 ******************************************************************************/
 
 const os = require('os')
-const ref = require('ref')
-const ffi = require('ffi')
+const ref = require('ref-napi')
+const ffi = require('ffi-napi')
 const path = require('path')
-const StructType = require('ref-struct')
+const StructType = require('ref-napi-struct')
 const EventEmitter = require('events').EventEmitter
 
 /**

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -10,7 +10,7 @@ const os = require('os')
 const ref = require('ref-napi')
 const ffi = require('ffi-napi')
 const path = require('path')
-const StructType = require('ref-napi-struct')
+const StructType = require('ref-struct-napi')
 const EventEmitter = require('events').EventEmitter
 
 /**


### PR DESCRIPTION
Tests: `$ npm i https://www.github.com/rticommunity/rticonnextdds-connector-js.git#feature/CON-173-napi`: 

Using node **8.17.0**: 
- Installation:
```
npm WARN notsup Unsupported engine for ffi-napi@3.0.1: wanted: {"node":">=10"} (current: {"node":"8.17.0","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: ffi-napi@3.0.1
npm WARN enoent ENOENT: no such file or directory, open '/home/sam/working/trees/connector/test/package.json'
npm WARN test No description
npm WARN test No repository field.
npm WARN test No README data
npm WARN test No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ffi-napi@3.0.1 install: `node-gyp-build`
```

Using node **10.22.0**:
- Installation: Success
- Simple example: Success
- Web socket example: Success

Using node **11.15.0**:
- Installation: Failure
```
../src/ffi.cc:11:54: error: ‘napi_get_instance_data’ was not declared in this scope
   napi_status status = napi_get_instance_data(env, &d);
                                                      ^
../src/ffi.cc: In function ‘Napi::Object BindingHook(Napi::Env, Napi::Object)’:
../src/ffi.cc:350:17: error: ‘napi_set_instance_data’ was not declared in this scope
       }, nullptr);
                 ^
ffi_bindings.target.mk:114: recipe for target 'Release/obj.target/ffi_bindings/src/ffi.o' failed
make: *** [Release/obj.target/ffi_bindings/src/ffi.o] Error 1
make: Leaving directory '/home/sam/working/trees/connector/test/node_modules/ffi-napi/build'
gyp ERR! build error 
```

Using node **12.18.0**
- Installation: Success
- Simple example: Success
- Web socket example: Success

Using node **13.14.0**
- Installation: Success
- Simple example: Success
- Web socket example: Success

Using node **14.9.0**
- Installation: Success
- Simple example: Failure:
```

#
# Fatal error in , line 0
# Check failed: result.second.
#
#
#
#FailureMessage Object: 0x7ffdfd6285a0
 1: 0xa6f6b1  [node]
 2: 0x19cdf14 V8_Fatal(char const*, ...) [node]
 3: 0xe58429 v8::internal::GlobalBackingStoreRegistry::Register(std::shared_ptr<v8::internal::BackingStore>) [node]
 4: 0xba3958 v8::ArrayBuffer::GetBackingStore() [node]
 5: 0x9c1290 napi_get_typedarray_info [node]
 6: 0x7f330c2ea3af  [/home/sam/working/trees/connector/test/node_modules/ffi-napi/node_modules/ref-napi/prebuilds/linux-x64/node.napi.node]
 7: 0x7f330c2eabc8  [/home/sam/working/trees/connector/test/node_modules/ffi-napi/node_modules/ref-napi/prebuilds/linux-x64/node.napi.node]
 8: 0x7f330c2ec7a1  [/home/sam/working/trees/connector/test/node_modules/ffi-napi/node_modules/ref-napi/prebuilds/linux-x64/node.napi.node]
 9: 0x7f330c2f301b Napi::details::CallbackData<void (*)(Napi::CallbackInfo const&), void>::Wrapper(napi_env__*, napi_callback_info__*) [/home/sam/working/trees/connector/test/node_modules/ffi-napi/node_modules/ref-napi/prebuilds/linux-x64/node.napi.node]
10: 0x9b8a5f  [node]
11: 0xbe25fb  [node]
12: 0xbe3ba6  [node]
13: 0xbe4226 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
14: 0x13fe159  [node]
Illegal instruction
```