### PR TITLE
GREEN-1938: Use the ffi-napi modules in tests

### DIFF
--- a/test/nodejs/test_rticonnextdds_data_access.js
+++ b/test/nodejs/test_rticonnextdds_data_access.js
@@ -8,7 +8,7 @@
 
 const path = require('path')
 const os = require('os')
-const ffi = require('ffi')
+const ffi = require('ffi-napi')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const expect = chai.expect

--- a/test/nodejs/test_rticonnextdds_input.js
+++ b/test/nodejs/test_rticonnextdds_input.js
@@ -8,7 +8,7 @@
 
 const path = require('path')
 const os = require('os')
-const ffi = require('ffi')
+const ffi = require('ffi-napi')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const expect = chai.expect


### PR DESCRIPTION
Some of the unit tests were requiring the ffi modules to test the ability
to extend the API. Since we updated package.json to use the ffi-napi module,
the ffi module is no longer present and these tests were failing.