### PR TITLE
CON-174: Handle armv8 architectures

### DIFF
--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -67,6 +67,15 @@ class _ConnectorBinding {
         default:
           throw new Error(os.platform() + ' not yet supported')
       }
+    } else if (os.arch() === 'arm64') {
+      switch (os.platform()) {
+        case 'linux':
+          libArch = 'armv8Linux4gcc7.3.0'
+          libName = 'librtiddsconnector.so'
+          break
+        default:
+          throw new Error(os.platform() + ' not yet supported')
+      }
     } else if (os.arch() === 'arm') {
       switch (os.platform()) {
         case 'linux':
@@ -76,6 +85,8 @@ class _ConnectorBinding {
         default:
           throw new Error(os.platform() + ' not yet supported')
       }
+    } else {
+      throw new Error(os.arch() + ' not yet supported')
     }
 
     if (additionalLib !== null) {


### PR DESCRIPTION
Tested on raspbuntu machine:
```
[sam@raspbuntu ~/connector-js-test-armv8]$ node node_modules/rticonnextdds-connector/examples/nodejs/simple/reader.js 
internal/fs/utils.js:230
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/home/sam/connector-js-test-armv8/node_modules/rticonnextdds-connector/rticonnextdds-connector/lib/armv8Linux4gcc7.3.0/librtiddsconnector.so'
    at Object.openSync (fs.js:458:3)
    at readFileSync (fs.js:360:35)
    at new DynamicLibrary (/home/sam/connector-js-test-armv8/node_modules/ffi-napi/lib/dynamic_library.js:68:23)
    at Object.Library (/home/sam/connector-js-test-armv8/node_modules/ffi-napi/lib/library.js:47:10)
    at new _ConnectorBinding (/home/sam/connector-js-test-armv8/node_modules/rticonnextdds-connector/rticonnextdds-connector.js:104:20)
    at Object.<anonymous> (/home/sam/connector-js-test-armv8/node_modules/rticonnextdds-connector/rticonnextdds-connector.js:148:24)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/sam/connector-js-test-armv8/node_modules/rticonnextdds-connector/rticonnextdds-connector/lib/armv8Linux4gcc7.3.0/librtiddsconnector.so'
}
[sam@raspbuntu ~/connector-js-test-armv8]$ mv ./node_modules/rticonnextdds-connector/rticonnextdds-connector/lib/armv8Linux4gcc7.3.0.back ./node_modules/rticonnextdds-connector/rticonnextdds-connector/lib/armv8Linux4gcc7.3.0
[sam@raspbuntu ~/connector-js-test-armv8]$ node node_modules/rticonnextdds-connector/examples/nodejs/simple/reader.js 
Waiting for publications...

```