### PR TITLE
CON-223: Removed max_objects_per_thread API

### DIFF
--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -2043,6 +2043,18 @@ class Connector extends EventEmitter {
       }
     }
   }
+
+  /**
+   * This method is deprecated since the max_objects_per_thread now grows
+   * dynamically.
+   *
+   * @private
+   *
+   * Note this method is deprecated in the Ironside release. This static method
+   * only exists to not break user's applications which are already using it.
+   */
+  static setMaxObjectsPerThread (value) {
+  }
 }
 
 // Export the API

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -135,7 +135,6 @@ class _ConnectorBinding {
       RTI_Connector_get_last_error_message: ['char *', []],
       RTI_Connector_get_native_instance: ['int', ['pointer', 'string', ref.refType('pointer')]],
       RTI_Connector_free_string: ['void', ['char *']],
-      RTI_Connector_set_max_objects_per_thread: ['int', ['int']],
       RTIDDSConnector_getJSONInstance:['char *', ['pointer', 'string']],
       // This API is only used in the unit tests
       RTI_Connector_create_test_scenario: ['int', ['pointer', 'int', 'pointer']]
@@ -2043,29 +2042,6 @@ class Connector extends EventEmitter {
         this.onDataAvailableRun = false
       }
     }
-  }
-
-  /**
-   * Allows you to increase the number of :class:`Connector` instances that 
-   * can be created.
-   *
-   * The default value is 2048 (which allows for approximately 15 instances 
-   * of :class:`Connector` to be created in a single application). If you need 
-   * to create more than 8 instances of :class:`Connector`, you can increase 
-   * the value from the default.
-   *
-   * .. note::
-   *   This is a static method. It can only be called before creating a 
-   *   :class:`Connector` instance.
-   *
-   * See `SYSTEM_RESOURCE_LIMITS QoS Policy 
-   * <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/users_manual/index.htm#users_manual/SYSTEM_RESOURCE_LIMITS_QoS.htm>`__
-   * in the *RTI Connext DDS Core Libraries User's Manual* for more information.
-   *
-   * @param {number} value The value for ``max_objects_per_thread``
-   */
-  static setMaxObjectsPerThread (value) {
-    _checkRetcode(connectorBinding.api.RTI_Connector_set_max_objects_per_thread(value))
   }
 }
 

--- a/test/nodejs/test_rticonnextdds_connector.js
+++ b/test/nodejs/test_rticonnextdds_connector.js
@@ -101,6 +101,18 @@ describe('Connector Tests', function () {
       expect(connector).to.be.instanceOf(rti.Connector)
   })
 
+  // Test for CON-200
+  it('Connector should not segfault if deleted twice', async function () {
+    const xmlProfile1 = path.join(__dirname, '/../xml/TestConnector.xml')
+    const xmlProfile2 = path.join(__dirname, '/../xml/TestConnector2.xml')
+    const fullXmlPath = xmlProfile1 + ';' + xmlProfile2
+    const connector = new rti.Connector('MyParticipantLibrary2::MyParticipant2', fullXmlPath)
+    expect(connector).to.exist
+    expect(connector).to.be.instanceOf(rti.Connector)
+    await connector.close()
+    await connector.close()
+  })
+
   describe('Connector callback test', function () {
     let connector
 


### PR DESCRIPTION
The behaviour of max_objects_per_thread has changed in the core, and it now
grows dynamically, meaning we no longer need to provide a way of setting it.