### PR TITLE
Feature/core 11993 connector

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,8 @@ def setup(app):
 # documentation.
 #
 html_theme_options = {
-    "collapse_navigation" : False
+    "collapse_navigation" : False,
+    "canonical_url" : "https://community.rti.com/static/documentation/connector/current/api/javascript/"
 }
 
 # The name of an image file (relative to this directory) to place at the top


### PR DESCRIPTION
@samuelraeburn, @alexcamposruiz, according to Andy Krassowski, users who search for Connector information get the 1.0.0 docs rather than the 1.1.0 ones (and usually they want the latest ones, I believe).

Andy writes, in an email:
"A simple Google search produces the 1.0.0 document as a result.

Try Google searching for "rti connector XML"

The Google search algorithm prioritizes matches based on the number of prior hits.  When 1.0.0 was the only document, it got lots of hits.
I could imagine asking Users to include the word "latest" in all searches and RTI moving a "latest" tag from 1.0.0 to 1.1.0 upon release.  Cumbersome and many users won't do that.

Another solution would be to replace old links with a page that redirects to the new link and offers another link for those who truly want the old documentation."

So, I have added a canonical link, which will tell Google to show the latest docs, rather than the ones with the most hits. As you can see in CORE-11993, we have done this for all of our sphinx-based docs on Community, but we apparently forgot about Connector.

If you approve this PR, I will create another one for rticonnextdds-connector-py.