### PR TITLE
CON-200, CON-92 

### DIFF
--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -135,7 +135,6 @@ class _ConnectorBinding {
       RTI_Connector_get_last_error_message: ['char *', []],
       RTI_Connector_get_native_instance: ['int', ['pointer', 'string', ref.refType('pointer')]],
       RTI_Connector_free_string: ['void', ['char *']],
-      RTI_Connector_set_max_objects_per_thread: ['int', ['int']],
       RTIDDSConnector_getJSONInstance:['char *', ['pointer', 'string']],
       // This API is only used in the unit tests
       RTI_Connector_create_test_scenario: ['int', ['pointer', 'int', 'pointer']]
@@ -2046,26 +2045,15 @@ class Connector extends EventEmitter {
   }
 
   /**
-   * Allows you to increase the number of :class:`Connector` instances that 
-   * can be created.
+   * This method is deprecated since the max_objects_per_thread now grows
+   * dynamically.
    *
-   * The default value is 2048 (which allows for approximately 15 instances 
-   * of :class:`Connector` to be created in a single application). If you need 
-   * to create more than 8 instances of :class:`Connector`, you can increase 
-   * the value from the default.
+   * @private
    *
-   * .. note::
-   *   This is a static method. It can only be called before creating a 
-   *   :class:`Connector` instance.
-   *
-   * See `SYSTEM_RESOURCE_LIMITS QoS Policy 
-   * <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/users_manual/index.htm#users_manual/SYSTEM_RESOURCE_LIMITS_QoS.htm>`__
-   * in the *RTI Connext DDS Core Libraries User's Manual* for more information.
-   *
-   * @param {number} value The value for ``max_objects_per_thread``
+   * Note this method is deprecated in the Ironside release. This static method
+   * only exists to not break user's applications which are already using it.
    */
   static setMaxObjectsPerThread (value) {
-    _checkRetcode(connectorBinding.api.RTI_Connector_set_max_objects_per_thread(value))
   }
 }
 

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -135,6 +135,7 @@ class _ConnectorBinding {
       RTI_Connector_get_last_error_message: ['char *', []],
       RTI_Connector_get_native_instance: ['int', ['pointer', 'string', ref.refType('pointer')]],
       RTI_Connector_free_string: ['void', ['char *']],
+      RTI_Connector_set_max_objects_per_thread: ['int', ['int']],
       RTIDDSConnector_getJSONInstance:['char *', ['pointer', 'string']],
       // This API is only used in the unit tests
       RTI_Connector_create_test_scenario: ['int', ['pointer', 'int', 'pointer']]
@@ -2045,15 +2046,26 @@ class Connector extends EventEmitter {
   }
 
   /**
-   * This method is deprecated since the max_objects_per_thread now grows
-   * dynamically.
+   * Allows you to increase the number of :class:`Connector` instances that 
+   * can be created.
    *
-   * @private
+   * The default value is 2048 (which allows for approximately 15 instances 
+   * of :class:`Connector` to be created in a single application). If you need 
+   * to create more than 8 instances of :class:`Connector`, you can increase 
+   * the value from the default.
    *
-   * Note this method is deprecated in the Ironside release. This static method
-   * only exists to not break user's applications which are already using it.
+   * .. note::
+   *   This is a static method. It can only be called before creating a 
+   *   :class:`Connector` instance.
+   *
+   * See `SYSTEM_RESOURCE_LIMITS QoS Policy 
+   * <https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/users_manual/index.htm#users_manual/SYSTEM_RESOURCE_LIMITS_QoS.htm>`__
+   * in the *RTI Connext DDS Core Libraries User's Manual* for more information.
+   *
+   * @param {number} value The value for ``max_objects_per_thread``
    */
   static setMaxObjectsPerThread (value) {
+    _checkRetcode(connectorBinding.api.RTI_Connector_set_max_objects_per_thread(value))
   }
 }
 

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -138,7 +138,8 @@ class _ConnectorBinding {
       RTI_Connector_set_max_objects_per_thread: ['int', ['int']],
       RTIDDSConnector_getJSONInstance:['char *', ['pointer', 'string']],
       // This API is only used in the unit tests
-      RTI_Connector_create_test_scenario: ['int', ['pointer', 'int', 'pointer']]
+      RTI_Connector_create_test_scenario: ['int', ['pointer', 'int', 'pointer']],
+      RTI_Connector_get_build_versions: ['int', [ref.refType('char *'), ref.refType('char *')]]
     })
   }
 }
@@ -2066,6 +2067,38 @@ class Connector extends EventEmitter {
    */
   static setMaxObjectsPerThread (value) {
     _checkRetcode(connectorBinding.api.RTI_Connector_set_max_objects_per_thread(value))
+  }
+
+  /**
+   * Returns the version of Connector.
+   *
+   * This static method provides the build IDs of the native libraries being used
+   * by Connector, as well as the version of the Connector API.
+   *
+   * .. note::
+   *   This is a static method. It can be called before creating a 
+   *   :class:`Connector` instance.
+   *
+   * @returns {string} A string containing information about the version of Connector.
+   */
+  static get_version() {
+      // Obtain version of Connector from package.json
+      const versionString = require('./package.json').version
+      // Parse numbers out of string
+      const versionNumbers = versionString.split('.')
+      // Now get the build IDs of the native libraries
+      const nativeConnectorVersion = ref.alloc('char *')
+      const nativeCoreCVersion = ref.alloc('char *')
+      _checkRetcode(connectorBinding.api.RTI_Connector_get_build_versions(
+          nativeCoreCVersion,
+          nativeConnectorVersion))
+
+      // Now create the string containing all of the above information
+      let versionStr = "RTI Connector for JavaScript, version "
+        + versionNumbers[0] + "." + versionNumbers[1] + "." + versionNumbers[2] + "\n"
+      versionStr += ref.readCString(nativeCoreCVersion.deref()) + "\n"
+      versionStr += ref.readCString(nativeConnectorVersion.deref())
+      return versionStr
   }
 }
 

--- a/test/nodejs/test_rticonnextdds_connector.js
+++ b/test/nodejs/test_rticonnextdds_connector.js
@@ -101,6 +101,18 @@ describe('Connector Tests', function () {
       expect(connector).to.be.instanceOf(rti.Connector)
   })
 
+  // Test for CON-200
+  it('Connector should not segfault if deleted twice', async function () {
+    const xmlProfile1 = path.join(__dirname, '/../xml/TestConnector.xml')
+    const xmlProfile2 = path.join(__dirname, '/../xml/TestConnector2.xml')
+    const fullXmlPath = xmlProfile1 + ';' + xmlProfile2
+    const connector = new rti.Connector('MyParticipantLibrary2::MyParticipant2', fullXmlPath)
+    expect(connector).to.exist
+    expect(connector).to.be.instanceOf(rti.Connector)
+    await connector.close()
+    await connector.close()
+  })
+
   describe('Connector callback test', function () {
     let connector
 

--- a/test/nodejs/test_rticonnextdds_connector.js
+++ b/test/nodejs/test_rticonnextdds_connector.js
@@ -101,6 +101,29 @@ describe('Connector Tests', function () {
       expect(connector).to.be.instanceOf(rti.Connector)
   })
 
+  it('is possible to obtain the current version of Connector', function () {
+    const version = rti.Connector.get_version()
+    expect(version).to.be.a.string
+
+    // The returned version string should contain four pieces of information:
+    // - the API version of Connector
+    // - the build ID of core.1.0
+    // - the build ID of dds_c.1.0
+    // - the build ID of lua_binding.1.0
+    // Expect "RTI Connector for JavaScript, version X.X.X"
+    let regex = /RTI Connector for JavaScript, version ([0-9][.]){2}[0-9]/
+    expect(regex.test(version)).deep.equals(true)
+    // Expect "NDDSCORE_BUILD_<VERSION>_<DATE>T<TIMESTAMP>Z"
+    regex = /.*NDDSCORE_BUILD_([0-9][.]){2}[0-9]_[0-9]{8}T[0-9]{6}Z/
+    expect(regex.test(version)).deep.equals(true)
+    // Expect "NDDSC_BUILD_<VERSION>_<DATE>T<TIMESTAMP>Z"
+    regex = /.*NDDSC_BUILD_([0-9][.]){2}[0-9]_[0-9]{8}T[0-9]{6}Z/
+    expect(regex.test(version)).deep.equals(true)
+    // Expect "RTICONNECTOR_BUILD_<VERSION>_<DATE>T<TIMESTAMP>Z"
+    regex = /.*RTICONNECTOR_BUILD_([0-9][.]){2}[0-9]_[0-9]{8}T[0-9]{6}Z/
+    expect(regex.test(version)).deep.equals(true)
+  })
+
   // Test for CON-200
   it('Connector should not segfault if deleted twice', async function () {
     const xmlProfile1 = path.join(__dirname, '/../xml/TestConnector.xml')


### PR DESCRIPTION
This change contains CON-200 and CON-92.

Note that the original squash to develop containing CON-200 also contained CON-223, so I had to cherry-pick that change (scheduled for Ironside) and manually remove it.

Original PRs:
CON-200: https://github.com/rticommunity/rticonnextdds-connector-js/pull/60
CON-92: https://github.com/rticommunity/rticonnextdds-connector-js/pull/61