### PR TITLE
PLATFORMS-2289. Added macOS 11 x64 to Connector JS 1.2.0 

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,8 +1,8 @@
 Release Notes
-=============
+*************
 
 Supported Platforms
-~~~~~~~~~~~~~~~~~~~
+===================
 
 *RTI Connector for JavaScript* has been tested with Node.js versions
 10.22.0, 11.15.0 and 12.13.0.
@@ -20,7 +20,7 @@ macOS® platforms. It has been tested on the following systems:
   * Wind River® Linux 8 (Arm v7) (Custom-supported platform)
 
 **macOS**
-  * macOS 10.13-10.15 (x64)
+  * macOS 10.13-10.15, 11 (x64)
 
 **Windows**
   * Windows 8 (x64)
@@ -32,16 +32,33 @@ macOS® platforms. It has been tested on the following systems:
 `the main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
-Version 1.1.0
-~~~~~~~~~~~~~
 
-*RTI Connector* 1.1.0 is built on `RTI Connext DDS 6.1.0 <https://community.rti.com/documentation/rti-connext-dds-610>`__.
+What's New in 1.2.0
+===================
+
+*RTI Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
+
+Support for macOS 11 (Big Sur) Systems on x64 CPUs
+--------------------------------------------------
+.. PLATFORMS-2289 
+
+This release has validated that the libraries for architecture 
+x64Darwin17clang9.0 can also be used on macOS 11 (Big Sur) systems with x64
+CPUs. For details on using this architecture, see 
+`the Platform Notes 
+<https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/platform_notes/index.htm#platform_notes/Mac_OS_Platforms.htm>`__.
+
+
+Previous Release
+================
+
+*RTI Connector* 1.1.0 was built on `RTI Connext DDS 6.1.0 <https://community.rti.com/documentation/rti-connext-dds-610>`__.
 
 What's New in 1.1.0
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Support added for ARMv8 architectures
-"""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-174 
 
 Connector for JavaScript now runs on ARMv8 architectures. Native libraries
@@ -49,7 +66,7 @@ built for ARMv8 Ubuntu 16.04 are now shipped alongside Connector. These librarie
 have been tested on ARMv8 Ubuntu 16.04 and ARMv8 Ubuntu 18.04.
 
 Support added for Node.js version 12
-""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-173 
 
 Previously, Node.js version 12 was not supported in *Connector* for JavaScript.
@@ -61,7 +78,7 @@ Connector for JavaScript.
 
 
 Sample state, instance state and view state can now be obtained in Connector
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-177 
 
 The :class:`SampleInfo` class in *Connector* has been extended to provide access to the
@@ -73,7 +90,7 @@ new feature.
 
 
 Support for accessing the key values of disposed instances
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-188 
 
 Support for disposing instances was added in *Connector* 1.0.0.
@@ -88,7 +105,7 @@ See :ref:`Accessing key values of disposed samples` for more
 information on this new feature.
 
 Connector for Javascript dependencies now locked to specific versions
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-220 
 
 ``package-lock.json`` has been committed, fixing the versions of *Connector for 
@@ -96,7 +113,7 @@ Javascript's* dependencies.
 
 
 Support for Security, Monitoring and other Connext DDS add-on libraries
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. CON-221
 
@@ -105,10 +122,10 @@ that Connext DDS features such as Monitoring and Security Plugins are now suppor
 Refer to :ref:`Loading Connext DDS Add-On Libraries` for more information.
 
 What's Fixed in 1.1.0
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 Creating two instances of Connector resulted in a license error
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Under some circumstances, it was not possible to create two *Connector* objects.
 The creation of the second *Connector* object failed due to a license error.
@@ -119,7 +136,7 @@ This issue has been fixed.
 
 
 Some larger integer values may have been corrupted by Connector's internal JSON parser
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The internal JSON parser used in *Connector* failed to identify integer numbers
 from double-precision floating-point numbers for certain values.
@@ -131,7 +148,7 @@ become corrupted. This problem has been resolved.
 
 
 Support for loading multiple configuration files
-""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A *Connector* object now supports loading multiple files. This allows separating
 the definition of types, QoS profiles, and *DomainParticipants* into different
@@ -145,7 +162,7 @@ files:
 
 
 Creating a Connector instance with a participant_qos tag in the XML may have resulted in a license error
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In some cases, if the XML configuration file of *Connector* contained a
 `<participant_qos>` tag within the definition of the *DomainParticipant*,
@@ -156,7 +173,7 @@ This problem has been resolved.
 
 
 Websocket example may have failed to run
-""""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The websocket example (available only in *Connector for Javascript*) may have 
 failed to run due to one of its dependencies, socket.io, removing a public API. 
@@ -165,8 +182,8 @@ This problem has been resolved.
 [RTI Issue ID CON-217]
 
 
-Version 1.0.0
-~~~~~~~~~~~~~
+What's New in 1.0.0
+-------------------
 
 1.0.0 is the first official release of *RTI Connector for JavaScript* as well as
 `RTI Connector for Python <https://community.rti.com/static/documentation/connector/1.0.0/api/python/index.html>`__.
@@ -175,4 +192,4 @@ If you had access to previous experimental releases, this release makes the prod
 more robust, modifies many APIs and adds new functionality. However the old 
 APIs have been preserved for backward compatibility as much as possible.
 
-*RTI Connector* 1.0.0 is built on `RTI Connext DDS 6.0.1 <https://community.rti.com/documentation/rti-connext-dds-601>`__.
+*RTI Connector* 1.0.0 was built on `RTI Connext DDS 6.0.1 <https://community.rti.com/documentation/rti-connext-dds-601>`__.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -38,16 +38,11 @@ What's New in 1.2.0
 
 *RTI Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
 
-Support for macOS 11 (Big Sur) Systems on x64 CPUs
---------------------------------------------------
+Support for macOS 11 (Big Sur) Systems
+--------------------------------------
 .. PLATFORMS-2289 
 
-This release has validated that the libraries for architecture 
-x64Darwin17clang9.0 can also be used on macOS 11 (Big Sur) systems with x64
-CPUs. For details on using this architecture, see 
-`the Platform Notes 
-<https://community.rti.com/static/documentation/connext-dds/current/doc/manuals/connext_dds_professional/platform_notes/index.htm#platform_notes/Mac_OS_Platforms.htm>`__.
-
+This release has validated that *Connector* can be used on macOS 11 (Big Sur) systems.
 
 Previous Release
 ================


### PR DESCRIPTION
Adding macOS 11 x64 to what's new in 1.2.0.