### PR TITLE
HMAINT-202 -- use npm v6 to update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.1.0",
+  "version": "1.2.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This corrects the changes to package-lock.json when using a new version of npm. This was created using npm 6.13.3.