### PR TITLE
CON-254: Document unsupport Node.JS v11 (#93)

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -233,7 +233,7 @@ The Monitoring and Security plugins are configured in XML, as described in the p
 links.
 
 To use RTI Connext DDS add-ons you need an RTI Connext DDS installation. To
-configure your environment so that Connector can load these additional libraries:
+configure your environment so that *Connector* can load these additional libraries:
 
 - Set your environment using::
 
@@ -248,7 +248,7 @@ configure your environment so that Connector can load these additional libraries
   <Connext DDS installation directory>\lib\<architecture>\
 
 .. note::
-    Each version of Connector can only load add-on libraries from its
+    Each version of *Connector* can only load add-on libraries from its
     corresponding Connext DDS release. You can see this correspondence in the
-    :ref:`release notes`. For example, Connector 1.1.0 can only
+    :ref:`release notes`. For example, *Connector* 1.1.0 can only
     load Connext DDS 6.1.0 add-on libraries.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,9 +22,6 @@ Or the GitHub repository:
 
 In order to access the examples, run npm with the GitHub repository.
 
-*Connector* works with Node.js versions 10.20.x [#f1]_ to 13.x.x [#f2]_. It currently doesn't work
-with versions 14+ because one of its dependencies is not yet compatible with that version.
-
 npm uses `node-gyp <https://github.com/nodejs/node-gyp>`__ to locally compile some of *Connector*'s
 dependencies. This requires Python 2.7 (it will not work with Python 3) and a relatively recent C++
 compiler (such as gcc 4.8+).
@@ -71,10 +68,3 @@ You can run the reader and the writer in any order, and you can run multiple
 instances of each at the same time. You can also run any other *DDS* application
 that publishes or subscribes to the *Square* topic. For example, you can use
 `RTI Shapes Demo <https://www.rti.com/free-trial/shapes-demo>`__.
-
-.. rubric:: Footnotes
-.. [#f1] Note that Connector for JavaScript is not compatible with versions of 
-   Node.js prior to v10.20.x.
-.. [#f2] Note that Connector for JavaScript is not compatible with Node.js v12.19.0
-   due to a regression that was introduced in that version of Node.js. Connector for JavaScript
-   works with Node.js versions 12.18.x and 12.20.x.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,26 +4,24 @@ Release Notes
 Supported Platforms
 -------------------
 
-*RTI Connector for JavaScript* has been tested with Node.js versions
-10.22.0, 11.15.0 and 12.13.0.
+*Connector* works with Node.js versions 10.20.x through 13.x.x,
+except for versions 11.x.x and 12.19.x [#f1]_.
 
 *Connector* uses a native C library that works on most Windows®, Linux® and
 macOS® platforms. It has been tested on the following systems:
 
 **Linux**
-  * CentOS™ 6.0, 6.2-6.4, 7.0 (x64)
-  * Red Hat® Enterprise Linux 6.0-6.5, 6.7, 6.8, 7, 7.3, 7.5, 7.6, 8  (x64)
-  * SUSE® Linux Enterprise Server 12 SP2  (x64)
-  * Ubuntu® 14.04, 16.04, 18.04, 20.04 LTS (x64)
-  * Ubuntu 16.04, 18.04 LTS (64-bit Arm® v8)
-  * Ubuntu 18.04 LTS (32-bit Arm v7)
-  * Wind River® Linux 8 (Arm v7) (Custom-supported platform)
+  * CentOS™ 7.0 (x64)
+  * Red Hat® Enterprise Linux 7, 7.3, 7.5, 7.6, 8 (x64)
+  * SUSE® Linux Enterprise Server 12 SP2 (x64)
+  * Ubuntu® 18.04 (x64, Arm v7, Arm v8)
+  * Ubuntu 20.04 LTS (x64)
 
 **macOS**
-  * macOS 10.13-10.15, 11 (x64)
+  * macOS 10.13-10.15 (x64)
+  * macOS 11 (x64 and Arm v8 tested via x64 libraries)
 
 **Windows**
-  * Windows 8 (x64)
   * Windows 10 (x64)
   * Windows Server 2012 R2 (x64)
   * Windows Server 2016 (x64)
@@ -32,24 +30,34 @@ macOS® platforms. It has been tested on the following systems:
 `the main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
+.. rubric:: Footnotes
+.. [#f1] Versions of Node.js prior to v10.20.x and version v11.x.x do not support n-api,
+   which is used by some of *Connector's* dependencies. Node.js v12.19.0 is not
+   compatible with *Connector* because of a regression introduced in
+   that version of Node.js.
+   Node.js 14+ does not work with *Connector* because one of *Connector's*
+   dependencies is not yet compatible with that version.
 
 What's New in 1.2.0
 -------------------
 
-*RTI Connector* 1.2.0 is built on `RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
+*RTI Connector* 1.2.0 is built on 
+`RTI Connext DDS 6.1.1 <https://community.rti.com/documentation/rti-connext-dds-611>`__.
 
 New Platforms
 ^^^^^^^^^^^^^
 
-RTI has validated that *Connector* can be used on macOS 11 (Big Sur) systems.
+*Connector* has been validated on macOS 11 (Big Sur) systems on x64 and Arm v8 
+CPUs (via x64 libraries).
 
 
 New API makes it easier to query what version of Connector is being used
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. CON-92 
 
-A new API has been added that provides the caller with the version of *Connector*
-and the version of the native libraries being used.
+A new API, :meth:`Connector.getVersion`, has been added that provides the
+caller with the version of *Connector* and the version of the native
+libraries being used.
 
 
 What's Fixed in 1.2.0


### PR DESCRIPTION
* CON-254: Document unsupport Node.JS v11

* CON-254: PR feedback

* Update docs/release_notes.rst

Co-authored-by: Alex Campos <alejandro@rti.com>

* CON-254: PR Feedback

* CON-254. Updating Supported Platforms ro match the PAM for 6.1.1.

* CON-254. Updating supported platforms.

Co-authored-by: Alex Campos <alejandro@rti.com>
Co-authored-by: adelleolson <adelle@rti.com>
(cherry picked from commit 5fe2b519bf58463ff9339315ececd3aa4a3c0391)