### PR TITLE
#fix HMAINT-202 -- new connector libraries for js, base on DDS 6.1.1 (20220309, bkprt)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.0-rc5",
+  "version": "1.2.0-rc6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.0-rc5",
+  "version": "1.2.0-rc6",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
updating libraries for candidate release rc6. This will be used as a test release for 1.2.0. Here are _BUILD_ strings:
Z-1510 | for i in */*.so */*.dll */*.dylib  ; do strings $i | grep _BUILD_ && echo found in $i; done
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-arm64/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/libnddsc.so
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/libnddscore.so
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in linux-x64/librtiddsconnector.so
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/nddsc.dll
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/nddscore.dll
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in win-x64/rtiddsconnector.dll
NDDSC_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/libnddsc.dylib
NDDSCORE_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/libnddscore.dylib
RTICONNECTOR_BUILD_6.1.1.0_20220309T000000Z_RTI_REL
found in osx-x64/librtiddsconnector.dylib