### PR TITLE
Update dependabot config to not create PRs for bumping deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "develop"
+    # For now, we only want dependabot updates for vulnerabilities, not for
+    # out-of-date dependencies. Setting this limit to 0 prevents dependabot
+    # from creating multiple PRs due to out-of-date dependencies (security
+    # related updates are not affected by this limit)
+    open-pull-requests-limit: 0


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#disabling-dependabot-version-updates

I think that to begin with we only want dependabot to report vulnerabilities. If we don't set this it will report for out-of-date dependencies.
See:
https://github.com/rticommunity/rticonnextdds-connector-js/pull/118
https://github.com/rticommunity/rticonnextdds-connector-js/pull/119
https://github.com/rticommunity/rticonnextdds-connector-js/pull/120
https://github.com/rticommunity/rticonnextdds-connector-js/pull/121
https://github.com/rticommunity/rticonnextdds-connector-js/pull/122

If this PR is accepted I will close those PRs