### PR TITLE
CON-261 CON-260: Document support node v18 + update node-gyp requirements

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -23,7 +23,7 @@ Or the GitHub repository:
 In order to access the examples, run npm with the GitHub repository.
 
 npm uses `node-gyp <https://github.com/nodejs/node-gyp>`__ to locally compile some of *Connector*'s
-dependencies. This requires a Python installation and a C++ compiler. Please refer
+dependencies. node-gyp requires a Python installation and a C++ compiler. Please refer
 to the `node-gyp documentation <https://github.com/nodejs/node-gyp#installation>`__
 for more details.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -23,11 +23,9 @@ Or the GitHub repository:
 In order to access the examples, run npm with the GitHub repository.
 
 npm uses `node-gyp <https://github.com/nodejs/node-gyp>`__ to locally compile some of *Connector*'s
-dependencies. This requires Python 2.7 (it will not work with Python 3) and a relatively recent C++
-compiler (such as gcc 4.8+).
-
-On Windows systems, you can install the `Windows Build Tools <https://www.npmjs.com/package/windows-build-tools>`__,
-which include both the Visual C++ compiler and Python 2.7.
+dependencies. This requires a Python installation and a C++ compiler. Please refer
+to the `node-gyp documentation <https://github.com/nodejs/node-gyp#installation>`__
+for more details.
 
 For more information, see :ref:`Supported Platforms`.
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 Supported Platforms
 -------------------
 
-*Connector* works with Node.js v17. It can also be used with
+*Connector* works with Node.js v17-18. It can also be used with
 Node.js versions 10.20.x through 13.x.x, except for versions
 11.x.x and 12.19.x [#f1]_.
 


### PR DESCRIPTION
Added v18 to supported versions of Node

Fixed our docs about node-gyp requirements.
For more details:
Removed recommendation to install windows-build-tools since it is no longer required with modern Node.JS versions (source: https://www.npmjs.com/package/windows-build-tools)
Removed specific version of Python/GCC. We were stating the Python2.7 is needed, which hasn't been true for a long time (see CON-260 description).