### PR TITLE
rticonnextdds-connector library changes and version string changes for release 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
Changed references in rticonnextdds-connector to latest develop branch changes in rticonnextdds-connector repository.
Changed version string to 1.2.2