### PR TITLE
Merge support/connector/1.2.0 to release/connector/1.2.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ copyright = '2022, Real-Time Innovations, Inc.'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
-release = '1.2.1'
-version = '1.2.1'
+release = '1.2.0'
+version = '1.2.0'
 
 master_doc = 'index'
 primary_domain = 'js'

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,15 +16,14 @@ macOS® platforms. It has been tested on the following systems:
   * Red Hat® Enterprise Linux 7, 7.3, 7.5, 7.6, 8 (x64)
   * SUSE® Linux Enterprise Server 12 SP2 (x64)
   * Ubuntu® 18.04 (x64, Arm v7, Arm v8)
-  * Ubuntu 20.04 LTS (x64)
+  * Ubuntu 20.04, 22.04 LTS (x64)
 
 **macOS**
-  * macOS 10.13-10.15 (x64)
+  * macOS 10.13-10.15, 12 (x64)
   * macOS 11 (x64 and Arm v8 tested via x64 libraries)
 
 **Windows**
-  * Windows 10 (x64)
-  * Windows Server 2012 R2 (x64)
+  * Windows 10, 11 (x64)
   * Windows Server 2016 (x64)
 
 *Connector* is supported in other languages in addition to JavaScript, see
@@ -39,14 +38,32 @@ repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
    Node.js v14 and Node.js v16 do not work with *Connector* because one of *Connector's*
    dependencies is not compatible with those versions.
 
-Version 1.2.1
--------------
+Version 1.2.2
+-----------------
 
-*Connector* 1.2.1 updates some third party dependencies that were found to contain
-vulnerabilities. *Connector* was not affected by these vulnerabilities.
+What's New in 1.2.2
+^^^^^^^^^^^^^^^^^^^
+
+*RTI Connector* 1.2.2 is built on 
+`RTI Connext DDS 6.1.2 <https://community.rti.com/documentation/rti-connext-dds-612>`__.
+
+Native Windows libraries updated to Visual Studio 2015
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+.. CON-276
+
+Previously, the native libraries shipped with Connector were built using Visual
+Studio 2013 (and accompanied by Microsoft's mscvr120 redistributable). These
+libraries are now built using Visual Studio 2015. The redistributable that is
+shipped has been updated accordingly.
 
 Previous Releases
 -----------------
+
+Version 1.2.1
+^^^^^^^^^^^^^
+
+*Connector* 1.2.1 updates some third party dependencies that were found to contain
+vulnerabilities. *Connector* was not affected by these vulnerabilities.
 
 Version 1.2.0
 ^^^^^^^^^^^^^

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.1",
+  "version": "1.2.2-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.1",
+  "version": "1.2.2-rc1",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -70,7 +70,7 @@ class _ConnectorBinding {
         case 'win32':
           libDir = 'win-x64'
           libName = 'rtiddsconnector.dll'
-          additionalLib = 'msvcr120.dll'
+          additionalLib = 'vcruntime140.dll'
           isWindows = true
           break
         default:


### PR DESCRIPTION
Pull in documentation changes, version string changes, and library changes from support/connector/1.2.0.
strings rticonnector/rticonnextdds-connector/libs/*/*core* in all library folders show "NDDSCORE_BUILD_6.1.2.0_20221014T000000Z_RTI_REL", which is correct.


