### PR TITLE
CON-278 -- rc2 with libraries from 20221028

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
 release = '1.2.0'
-version = '1.2.0'
+version = '1.2.2'
 
 master_doc = 'index'
 primary_domain = 'js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2-rc1",
+  "version": "1.2.2-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2-rc1",
+  "version": "1.2.2-rc2",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
Updated git library links to the latest build in the common library repository. Changed docs version to 1.2.2 and bump the rc version to rc2.