### PR TITLE
CON-282: Document known limitations

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,21 +6,11 @@ Getting Started
 Installing RTI Connector for JavaScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*RTI Connector for JavaScript* can be installed with npm in two ways:
-
-You can pass the package name:
+*RTI Connector for JavaScript* can be installed with npm:
 
 .. code:: bash
 
     $ npm install rticonnextdds-connector
-
-Or the GitHub repository:
-
-.. code:: bash
-
-   $ npm install https://www.github.com/rticommunity/rticonnextdds-connector-js.git
-
-In order to access the examples, run npm with the GitHub repository.
 
 npm uses `node-gyp <https://github.com/nodejs/node-gyp>`__ to locally compile some of *Connector*'s
 dependencies. node-gyp requires a Python installation and a C++ compiler. Please refer

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 Supported Platforms
 -------------------
 
-*Connector* works with Node.js v17-18. It can also be used with
+*Connector* works with Node.js v17.0.0-v18.7.0. It can also be used with
 Node.js versions 10.20.x through 13.x.x, except for versions
 11.x.x and 12.19.x [#f1]_.
 
@@ -37,6 +37,7 @@ repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
    that version of Node.js.
    Node.js v14 and Node.js v16 do not work with *Connector* because one of *Connector's*
    dependencies is not compatible with those versions.
+   Node.js versions greater than v18.7.0 are not currently supported.
 
 Native Windows libraries updated to Visual Studio 2015
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated documentation to note the known limitations of CON-277 and CON-262.

CON-277: Versions of Node.js >= 18.8.0 are unsupported.
CON-262: Versions of npm >= v7 are not able to install Connector via a github URL.

In order to document CON-262, I simply removed the documentation that lists `npm install <github_url>` as a valid method of installation.