### PR TITLE
CON-278 -- final version string for 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2-rc3",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2-rc3",
+  "version": "1.2.2",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
Removing the -rcX from the version string and ran "npm i --package-lock-only". Double checked libraries and they are all pointing to build NDDSCORE_BUILD_6.1.2.0_20221111T000000Z_RTI_REL.