### PR TITLE
CON-248: Add warning regarding the use of Infinity

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -239,6 +239,13 @@ then you must take the following into account.
   The :meth:`Instance.setNumber()` operation can safely handle ``abs(value) < 2^53``,
   whereas the :meth:`SampleIterator.getNumber()` operation can safely handle ``abs(value) <= 2^53``.
 
+.. note::
+
+  The use of "Infinity", "-Infinity" and "-0" has some potential pitfalls and is
+  not recommended. If your application must use these values, refer to
+  `this knowledge base article <https://community.rti.com/kb/advanced-data-access-using-connector-javascript>`__
+  for more information.
+
 Accessing structs
 ^^^^^^^^^^^^^^^^^
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -107,10 +107,6 @@ Support added for handling large 64-bit integers
 Support has been improved for both getting and setting large (greater than 2^53)
 64-bit values. See :ref:`section-access-64-bit-integers-js` for more information.
 
-Note that on Windows systems, the string representations of Not a Number and
-infinity (e.g., ``'NaN'``, ``'Infinity'``) are not valid values for a Number.
-They are valid inputs on other systems.
-
 [RTI Issue ID CON-190]
 
 


### PR DESCRIPTION
The original task here was to remove the limitation on Windows usage of "Infinity" since we now ship VS2015 as base.
After some investigation, I decided that the current level of support that we have for "Infinity", "-Infinity" and "-0" leaves a lot to be desired (see Fabrizio's article here: https://community.rti.com/kb/advanced-data-access-using-connector-javascript).
So I decided to just remove all mention of it completely and a add a disclaimer that there are some gotchas to be aware of if using that functionality.

New docs:
![Screenshot from 2023-09-12 11-38-29](https://github.com/rticommunity/rticonnextdds-connector-js/assets/24991686/545ef5a8-76e7-4eeb-ae4f-383956c9c8d9)
