### PR TITLE
CON-298 change package version to 1.3.0 ...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rticonnextdds-connector",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.pdf",
       "dependencies": {
         "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
First step in creating support/connector/1.3.0 is the version string change. The npm i --package-lock-json command was issued after changing the package.json version string from 1.2.2 to 1.3.0. The changes in package-lock-json should be minimal.