### PR TITLE
COMMUNITY-69 & COMMUNITY-70 | add network isolation for tests containers and fix doc generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update \
     && apt-get install -y gcc g++ git make python3 python3-pip python3-venv \
     && useradd -u 789 -m jenkins
 
-RUN npm install -g npm jsdoc
+RUN mkdir -p /opt/node_deps \
+    && npm config set prefix /opt/node_deps \
+    && chmod o+rwx /opt/node_deps
 
 RUN python3 -m venv /opt/venv \
     && chmod -R o+rwx /opt/venv 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN apt-get update \
     && useradd -u 789 -m jenkins
 
 RUN mkdir -p /opt/node_deps \
-    && npm config set prefix /opt/node_deps \
-    && chmod o+rwx /opt/node_deps
+    && npm config set prefix '/opt/node_deps' \
+    && chmod -R a+rwx /opt/node_deps
 
 RUN python3 -m venv /opt/venv \
     && chmod -R o+rwx /opt/venv 
 
-ENV PATH="/opt/venv/bin:/home/jenkins/npm/bin:/home/jenkins/.local/bin:${PATH}"
+ENV PATH="/opt/node_deps/bin:/opt/venv/bin:/home/jenkins/npm/bin:/home/jenkins/.local/bin:${PATH}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                 }
 
                 stages {
-                    stage("Checkout repo") {
+                    stage('Checkout repo') {
                         steps {
                             echo "[INFO] Building from ${pwd()}..."
 
@@ -70,7 +70,7 @@ pipeline {
                         }
                     }
 
-                    stage("Downloading dependencies") {
+                    stage('Downloading dependencies') {
                         agent {
                             dockerfile {
                                 additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
@@ -97,11 +97,11 @@ pipeline {
                         }
                     }
 
-                    stage("Run tests") {
+                    stage('Run tests') {
                         agent {
                             dockerfile {
                                 additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
-                                args "--network none"
+                                args '--network none'
                                 reuseNode true
                             }
                         }
@@ -112,7 +112,7 @@ pipeline {
 
                         post {
                             always {
-                                junit(testResults: "test-results.xml")
+                                junit(testResults: 'test-results.xml')
                             }
                         }
                     }
@@ -123,7 +123,7 @@ pipeline {
         stage('Build doc') {
             agent {
                 dockerfile {
-                    additionalBuildArgs  "--build-arg NODE_VERSION=18"
+                    additionalBuildArgs  '--build-arg NODE_VERSION=18'
                     reuseNode true
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,6 +132,7 @@ pipeline {
 
             steps {
                 dir('docs') {
+                    sh 'npm install -g jsdoc'
                     sh 'pip install -r requirements.txt --no-cache-dir'
                     sh 'make html'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                                 additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
                                 customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                                 reuseNode true
-                            } 
+                            }
                         }
 
                         steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                    node {
                         customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                         label 'docker'
-                    } 
+                    }
                 }
                 axes {
                     axis {
@@ -105,7 +105,7 @@ pipeline {
                                 customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                                 args "--network none"
                                 reuseNode true
-                            } 
+                            }
                         }
 
                         steps {
@@ -127,7 +127,7 @@ pipeline {
                 dockerfile {
                     additionalBuildArgs  "--build-arg NODE_VERSION=18"
                     reuseNode true
-                } 
+                }
             }
 
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,9 +84,9 @@ pipeline {
 
                                 withCredentials([string(credentialsId: 'artifactory-path', variable: 'ARTIFACTORY_PATH')]) {
                                     catchError(
-                                        message: "Library download failed",
-                                        buildResult: "UNSTABLE",
-                                        stageResult: "UNSTABLE"
+                                        message: 'Library download failed',
+                                        buildResult: 'UNSTABLE',
+                                        stageResult: 'UNSTABLE'
                                     ) {
                                         sh "python resources/scripts/download_latest_libs.py --storage-url ${servers.ARTIFACTORY_URL} --storage-path \$ARTIFACTORY_PATH -o ."
                                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,6 @@ pipeline {
                         agent {
                             dockerfile {
                                 additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
-                                customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                                 reuseNode true
                             }
                         }
@@ -102,7 +101,6 @@ pipeline {
                         agent {
                             dockerfile {
                                 additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
-                                customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                                 args "--network none"
                                 reuseNode true
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,6 +132,7 @@ pipeline {
 
             steps {
                 dir('docs') {
+                    sh 'npm config set prefix \'/opt/node_deps\''
                     sh 'npm install -g jsdoc'
                     sh 'pip install -r requirements.txt --no-cache-dir'
                     sh 'make html'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,8 +100,8 @@ pipeline {
                     stage('Run tests') {
                         agent {
                             dockerfile {
-                                additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
                                 args '--network none'
+                                additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
                                 reuseNode true
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,7 @@ pipeline {
         stage('Build & Test') {
             matrix {
                 agent {
-                   dockerfile {
-                        additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
+                   node {
                         customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
                         label 'docker'
                     } 
@@ -72,6 +71,14 @@ pipeline {
                     }
 
                     stage("Downloading dependencies") {
+                        agent {
+                            dockerfile {
+                                additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
+                                customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
+                                reuseNode true
+                            } 
+                        }
+
                         steps {
                             dir ('rticonnextdds-connector') {
                                 sh 'pip install -r resources/scripts/requirements.txt'
@@ -92,6 +99,15 @@ pipeline {
                     }
 
                     stage("Run tests") {
+                        agent {
+                            dockerfile {
+                                additionalBuildArgs  "--build-arg NODE_VERSION=${NODE_VERSION}"
+                                customWorkspace "/rti/jenkins/workspace/${env.JOB_NAME}/${NODE_VERSION}"
+                                args "--network none"
+                                reuseNode true
+                            } 
+                        }
+
                         steps {
                             sh 'npm run test-junit'
                         }


### PR DESCRIPTION
To fix COMMUNITY-69 I added `--network none` to the docker run arguments to avoid interferences among the tests.
To fix COMMUNITY-70 I created a new directory (`/opt/node_deps`) inside the container and set it as the npm prefix.