### PR TITLE
COMMUNITY-71 | Add a new mechanism to publish only the documentation when necessary

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -2,9 +2,9 @@ name: Connector - Build Doc
 
 on:
   push:
-    # Pattern matched against v<MAJOR>.<MINOR>.<PATCH>
+    # Pattern matched against v<MAJOR>.<MINOR>.<PATCH>-doc
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-doc'
     branches:
       - 'master'
       - 'release/connector/*'
@@ -62,6 +62,6 @@ jobs:
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-          aws_bucket: ${{ secrets.AWS_BUCKET }}
+          aws_bucket: ${{ secrets.AWS_DOC_BUCKET }}
           source_dir: 'docs/_build/html/'
           destination_dir: "documentation/connector/${{ steps.vars.outputs.tag }}/api/javascript/"


### PR DESCRIPTION
From now on, to publish the doc we should use a tag with the format v<MAJOR>.<MINOR>.<PATCH>-doc to publish only the doc when it is necessary.

The original tag format v[0-9]+.[0-9]+.[0-9]+ will be only used to publish connector into the NPM repository. DO NOT USE THIS ONE UNTIL CONNECTOR IS READY TO BE SHIPPED!!!!