### PR TITLE
COMMUNITY-71 | Remove the -doc suffix from the version string when it is obtained from the tag

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Getting version from tag
         id: vars
         if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "tag=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo $GITHUB_REF | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
       - name: Publish HTML documentation
         if: startsWith(github.ref, 'refs/tags/v')
@@ -64,4 +64,4 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ secrets.AWS_DOC_BUCKET }}
           source_dir: 'docs/_build/html/'
-          destination_dir: "documentation/connector/${{ steps.vars.outputs.tag }}/api/javascript/"
+          destination_dir: "documentation/connector/${{ steps.vars.outputs.version }}/api/javascript/"


### PR DESCRIPTION
The only part that we need from that string is the version digits (X.Y.Z) the other characters should be filtered-out.