### PR TITLE
COMMUNITY-72 | Fix documentation publication to AWS S3 (#176)

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -56,12 +56,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: echo "version=$(echo $GITHUB_REF | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" >> $GITHUB_OUTPUT
 
+      - name: Install AWS CLI
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli
+
       - name: Publish HTML documentation
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: shallwefootball/s3-upload-action@master
-        with:
-          aws_key_id: ${{ secrets.AWS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-          aws_bucket: ${{ secrets.AWS_DOC_BUCKET }}
-          source_dir: 'docs/_build/html/'
-          destination_dir: "documentation/connector/${{ steps.vars.outputs.version }}/api/javascript/"
+        run: |
+          aws s3 sync --acl public-read docs/_build/html/ s3://${{ secrets.AWS_DOC_BUCKET }}/documentation/connector/${{ steps.vars.outputs.version }}/api/javascript/
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+


### PR DESCRIPTION
* COMMUNITY-72: fix secret name

* COMMUNITY-72: change s3 upload action

* Revert "COMMUNITY-72: change s3 upload action"

This reverts commit 42484fef8b88b5c109d4623db63bfd5a862639f8.

* COMMUNITY-72: specify endpoint to the action

* COMMUNITY-72: add double commas

* COMMUNITY-72: fix syntax

* COMMUNITY-72: replace the action with the s3 CLI

* COMMUNITY-72: make doc public when it is published