### PR TITLE
COMMUNITY-77 | Remove tag trigger to publish to npm registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,6 @@ name: Connector - Build & Test
 
 on:
   push:
-    # Pattern matched against v<MAJOR>.<MINOR>.<PATCH>
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
     branches:
       - 'master'
       - 'release/connector/*'
@@ -118,35 +115,6 @@ jobs:
           name: Tests results
           path: 'test-results.json'
           reporter: mocha-json
-
-  publish:
-    runs-on: ubuntu-latest
-    name: Publish Connector JS
-    if: startsWith(github.ref, 'refs/tags/v')
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          submodules: 'true'
-
-      - name: Download Python Deps
-        run: pip install -r resources/scripts/requirements.txt
-        working-directory: ./rticonnextdds-connector
-
-      - name: Download libs
-        run: python3 resources/scripts/download_libs.py --storage-url ${{ secrets.RTI_AWS_BUCKET }} --storage-path ${{ secrets.RTI_AWS_PATH }} -o .
-        working-directory: ./rticonnextdds-connector
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-
-      - name: Publish npm package
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   commentpr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The removal of this trigger will avoid accidental publications.