### PR TITLE
CON-287: Update OpenLayers dependency in web_socket's Map example.

### DIFF
--- a/examples/nodejs/web_socket/indexMaps.html
+++ b/examples/nodejs/web_socket/indexMaps.html
@@ -13,7 +13,7 @@
     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
     <script src="/socket.io/socket.io.js"></script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-    <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v6.0.1/build/ol.js"></script>
+    <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/main/dist/en/v6.0.1/build/ol.js"></script>
     <style>
       .map {
         width: 100%;


### PR DESCRIPTION
The URL of the CDN used for this dependency has been broken for some time, and it's now been fixed.