### PR TITLE
Use the current lts instead of the latest one

### DIFF
--- a/ci_config.yaml
+++ b/ci_config.yaml
@@ -2,5 +2,5 @@ node_versions:
   - "18"
   - "19"
   - "20"
-  - "lts"
+  - "lts-iron"
 publish_version: "20"

--- a/ci_config.yaml
+++ b/ci_config.yaml
@@ -2,5 +2,4 @@ node_versions:
   - "18"
   - "19"
   - "20"
-  - "lts-iron"
 publish_version: "20"


### PR DESCRIPTION
This could avoid some CI failures in the future if node introduces breaking changes.

Close #195 

List of node versions and its names: https://nodejs.org/en/about/previous-releases