### PR TITLE
DOC-585: updating Connector getting started instructions to mention <version>

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,6 +19,17 @@ for more details.
 
 For more information, see :ref:`Supported Platforms`.
 
+The above command installs the latest version of *Connector* by default. To
+install a specific version, use this command:
+
+.. code-block:: console
+
+    $ npm install rticonnextdds-connector@<version>
+
+where ``<version>`` is any valid *Connector* version on the
+`npm rticonnextdds-connector versions <https://www.npmjs.com/package/rticonnextdds-connector?activeTab=versions>`__
+page.
+
 Running the examples
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### PR Description
I originally created this PR to release/connector/1.3.1 ([here](https://github.com/rticommunity/rticonnextdds-connector-js/pull/214)), but that was wrong. Connector 1.3.1 is associated with Connext 7.3.0.2 and is final. Any future changes I need to make to Connector documentation for next releases need to happen in develop and support/connector/1.3.0. 

I have cherry-picked the commit in the defunct PR to this one.

Note: Python and C# have a similar issue. Those doc changes have already been made in [this PR](https://bitbucket.rti.com/projects/CONNEXT/repos/connextdds/pull-requests/19705/overview).

The doc output associated with this PR is here: https://jenkins-community.rti.com/job/ci/job/connector-js/job/rticonnextdds-connector-js-doc/view/change-requests/job/PR-215/Connector_20Documentation/. (Once you open this URL, right-click any topic, such as 2. Getting Started, and open in a new tab. That way, the link to the npm site will work. (It doesn't work from within Jenkins.))