### PR TITLE
DOC-611: updating Connector getting started instructions to mention <version> (backporting DOC-585)

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,6 +19,17 @@ for more details.
 
 For more information, see :ref:`Supported Platforms`.
 
+The above command installs the latest version of *Connector* by default. To
+install a specific version, use this command:
+
+.. code-block:: console
+
+    $ npm install rticonnextdds-connector@<version>
+
+where ``<version>`` is any valid *Connector* version on the
+`npm rticonnextdds-connector versions <https://www.npmjs.com/package/rticonnextdds-connector?activeTab=versions>`__
+page.
+
 Running the examples
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Cherry-picking this PR: https://github.com/rticommunity/rticonnextdds-connector-js/pull/215

The doc output associated with this PR is here: https://jenkins-community.rti.com/job/ci/job/connector-js/job/rticonnextdds-connector-js-doc/view/change-requests/job/PR-221/Connector_20Documentation/getting_started.html