### PR TITLE
DOC-532: Update Connector copyrights

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'RTI Connector for JavaScript'
-copyright = '2024, Real-Time Innovations, Inc.'
+copyright = '2024, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -13,17 +13,20 @@ August 2024. |br|
 
 .. rubric:: License
 
+RTI Connector for JavaScript is part of the Connext
+Professional Package. If you have a valid license for the RTI Connext
+Professional Package, such license shall govern your use of
+RTI Connector for JavaScript. All other use of this software shall
+be governed solely by the terms of RTI's Software License for Non-Commercial
+Use #4040, included at the top level of the `Connector for JavaScript repository
+<https://github.com/rticommunity/rticonnextdds-connector-js>`__.
+
+.. rubric:: Trademarks
+
 RTI, Real-Time Innovations, Connext, Connext Drive, NDDS, the RTI logo, 
 1RTI and the phrase, “Your Systems. Working as one.” are registered 
 trademarks, trademarks or service marks of Real-Time Innovations, Inc. 
 All other trademarks belong to their respective owners.
-
-.. rubric:: Trademarks
-
-RTI, Real-Time Innovations, Connext, NDDS, the RTI logo, 1RTI and the
-phrase, “Your Systems. Working as one.” are registered trademarks, trademarks
-or service marks of Real-Time Innovations, Inc. All other trademarks belong to
-their respective owners.
 
 .. rubric:: Copy and Use Restrictions
 
@@ -113,3 +116,13 @@ Website: https://support.rti.com/ |br|
     OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
     SUCH DAMAGE.
 
+.. rubric:: Notices
+
+Any deprecations or removals noted in this document serve as notice under 
+the Real-Time Innovations, Inc. Maintenance Policy #4220 and/or any other 
+agreements by and between RTI and customer regarding maintenance and support 
+of RTI's software.
+
+*Deprecated* means that the item is still supported in the release, but will 
+be removed in a future release. *Removed* means that the item is discontinued 
+or no longer supported. 

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -50,8 +50,6 @@ Phone: (408) 990-7444 |br|
 Email: support@rti.com |br|
 Website: https://support.rti.com/ |br|
 
-© 2022 RTI
-
 .. rubric:: External Third-Party Software Used in Connector
 
 **Lua**

--- a/docs/copyright_license.rst
+++ b/docs/copyright_license.rst
@@ -9,18 +9,14 @@ Copyrights and License
 © 2024 Real-Time Innovations, Inc. |br|
 All rights reserved.  |br|
 Printed in U.S.A. First printing.  |br|
-March 2024. |br|
+August 2024. |br|
 
 .. rubric:: License
 
-RTI Connector for JavaScript is part of the Connext
-Professional Package. If you have a valid license for the RTI Connext
-Professional Package, such license shall govern your use of
-RTI Connector for JavaScript. All other use of this software shall
-be governed solely by the terms of RTI’s Software License for Non-Commercial
-Use #4040, included at the top level of the `Connector for JavaScript repository
-<https://github.com/rticommunity/rticonnextdds-connector-js>`__.
-
+RTI, Real-Time Innovations, Connext, Connext Drive, NDDS, the RTI logo, 
+1RTI and the phrase, “Your Systems. Working as one.” are registered 
+trademarks, trademarks or service marks of Real-Time Innovations, Inc. 
+All other trademarks belong to their respective owners.
 
 .. rubric:: Trademarks
 
@@ -31,15 +27,14 @@ their respective owners.
 
 .. rubric:: Copy and Use Restrictions
 
-No part of this publication may be reproduced, stored in a retrieval system,
-or transmitted in any form (including electronic, mechanical, photocopy, and
-facsimile) without the prior written permission of Real-Time Innovations, Inc.
-The software described in this document is furnished under and subject to the
-RTI software license agreement. The software may be used or copied only under
-the terms of the license agreement.
-
-This is an independent publication and is neither affiliated with, nor
-authorized, sponsored, or approved by, Microsoft Corporation.
+No part of this publication may be reproduced, stored in a retrieval system, 
+or transmitted in any form (including electronic, mechanical, photocopy, 
+and facsimile) without the prior written permission of Real-Time 
+Innovations, Inc. The software described in this document is furnished 
+solely under and subject to RTI's standard terms and conditions available 
+at https://www.rti.com/terms and in accordance with your License 
+Acknowledgement Certificate (LAC) and Maintenance and Support Certificate 
+(MSC), except to the extent otherwise agreed to in writing by RTI.
 
 The security features of this product include software developed by the
 OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/). 


### PR DESCRIPTION
Updated copyright year in conf.py
Updated copyright year and text in copyright_license.rst

[Doc output](https://jenkins-community.rti.com/job/ci/job/connector-js/job/rticonnextdds-connector-js-doc/view/change-requests/job/PR-222/Connector_20Documentation/copyright_license.html#)