### PR TITLE
CON-275: Add initial support for osx-arm64

### DIFF
--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -33,6 +33,9 @@ class _ConnectorBinding {
       if (os.platform() === 'linux') {
         libDir = 'linux-arm64'
         libName = 'librtiddsconnector.so'
+      } else if (os.platform() === 'darwin') {
+        libDir = 'osx-arm64'
+        libName = 'librtiddsconnector.dylib'
       } else {
         throw new Error('This platform (' + os.platform() + ' ' + os.arch() + ') is not supported')
       }


### PR DESCRIPTION
Output log: [CON-275_test.log](https://github.com/user-attachments/files/18007308/CON-275_test.log)