### PR TITLE
CON-326: Allow returning samples, enhance wait to be able to return samples before actually waiting.

### DIFF
--- a/docs/input.rst
+++ b/docs/input.rst
@@ -177,6 +177,27 @@ for example:
 
 See more information and examples in :ref:`Accessing the data`.
 
+Returning data and meta-data samples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The methods :meth:`Input.take()` and :meth:`Input.read()` make data accesible
+through the :meth:`Input.samples` collection. This data is available until the
+next call to :meth:`Input.take()` or :meth:`Input.read()`.
+
+In some situations, data may need to be returned sooner so that new data can be
+received. To do that, you can explicitly call :meth:`Input.returnSamples()`:
+
+.. testcode::
+
+   input.returnSamples()
+
+It is also possible to return samples when calling
+:meth:`Input.wait()` with the ``returnSamples`` parameter set to ``true``:
+
+.. testcode::
+
+   input.wait({ returnSamples: true })
+
 Accessing sample meta-data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -257,29 +257,6 @@ function _isObject (value) {
   return typeof value === 'object' && value !== null
 }
 
-
-/**
- * Parses arguments into an options object with values based on the supplied
- * keys. The order of keys determines the order of the arguments being parsed.
- *
- * @param {Array} args - The arguments to parse
- * @param {Array} keys - The in-order keys to use to parse the arguments
- * @return {object} The options object with the parsed values
- */
-function _parseOptions (args, keys) {
-  let options = {};
-  let i = 0;
-
-  for (let key of keys) {
-    if (i >= args.length) break;
-    if (args[i] === undefined) break;
-    options[key] = args[i];
-    i++;
-  }
-
-  return options;
-}
-
 /**
  * Function used to get any value from either the samples or infos (depending
  * on the supplied getter). The type of the fieldName need not be specified.
@@ -1228,18 +1205,16 @@ class Input {
    * @returns {Promise} A ``Promise`` which will be resolved once data is
    *   available, or rejected if the timeout expires.
    */
-  wait ({timeout = -1, returnSamples = false} = {}) {
+  wait({ timeout, returnSamples } = {}) {
     return new Promise((resolve, reject) => {
       /* if the first parameter was not an object, parse it */
       if (!_isObject(arguments[0])) {
-        ({
-          timeout = -1,
-          returnSamples = false,
-        }) = _parseOptions(arguments, [
-          'timeout',
-          'returnSamples'
-        ])
+        [ timeout, returnSamples ] = arguments
       }
+
+      /* Assign defaults */
+      timeout ??= -1
+      returnSamples ??= false
 
       if (!_isNumber(timeout)) {
         throw new TypeError('timeout must be a number')

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -1198,7 +1198,6 @@ class Input {
    *   By default, infinite.
    * @param {boolean} [options.returnSamples] Whether to return samples before waiting.
    *   By default ``True``. Set it to ``False`` for backwards compatibility.
-   * @
    * @throws {TimeoutError} :class:`TimeoutError` will be thrown if the
    *   timeout expires before data is received.
    * @returns {Promise} A ``Promise`` which will be resolved once data is

--- a/rticonnextdds-connector.js
+++ b/rticonnextdds-connector.js
@@ -1197,8 +1197,7 @@ class Input {
    * @param {number} [options.timeout] The maximum time to wait, in milliseconds.
    *   By default, infinite.
    * @param {boolean} [options.returnSamples] Whether to return samples before waiting.
-   *   By default and for backwards compatibility, ``False``.
-   *   It is recommended to set it to ``True`` for most scenarios.
+   *   By default ``True``. Set it to ``False`` for backwards compatibility.
    * @
    * @throws {TimeoutError} :class:`TimeoutError` will be thrown if the
    *   timeout expires before data is received.
@@ -1214,7 +1213,7 @@ class Input {
 
       /* Assign defaults */
       timeout ??= -1
-      returnSamples ??= false
+      returnSamples ??= true
 
       if (!_isNumber(timeout)) {
         throw new TypeError('timeout must be a number')


### PR DESCRIPTION
* Added new `returnSamples` method to `Input` class.

This requires accessing a new native function, thus requires new native libraries.

You can see the accompanying PR for Python rticommunity/rticonnextdds-connector-py#179.