### PR TITLE
CON-329: publish connector for every active branch automatically

### DIFF
--- a/resources/jenkins/build_and_test.groovy
+++ b/resources/jenkins/build_and_test.groovy
@@ -148,8 +148,12 @@ pipeline {
             }
 
             when {
+                anyOf {
+                    branch comparator: 'GLOB', pattern: 'release/connector/*'
+                    branch comparator: 'GLOB', pattern: 'support/connector/*'
+                    branch comparator: 'EQUALS', pattern: 'master'
+                }
                 beforeAgent true
-                tag pattern: /v\d+\.\d+\.\d+-dev/, comparator: "REGEXP"
             }
 
             steps {

--- a/resources/scripts/publish.sh
+++ b/resources/scripts/publish.sh
@@ -16,6 +16,22 @@ build_id=$(strings ${libraries[0]} | grep -o 'BUILD_.*')
 jq ". += {\"rti.build-id\": \"${build_id}\"}" package.json > package.json.tmp
 mv package.json.tmp package.json
 
+# Get current git branch
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# If branch doesn't start with release/connector, update the version
+if [[ ! "$current_branch" =~ ^release/connector ]]; then
+    # Append -dev to the current package version
+    new_version="${package_version}-dev"
+
+    # Update package.json with new version
+    jq ".version = \"${new_version}\"" package.json > package.json.tmp
+    mv package.json.tmp package.json
+
+    package_version=$new_version
+    echo "Updated version to ${package_version} for non-release branch"
+fi
+
 # If publishing to a repository other than the default one, add the Build ID to the
 # version string and unpublish the package in case it was already published to the
 # internal repo.


### PR DESCRIPTION
It is not necessary to push any tag to the repository, connector will be published internally when a change is pushed to release, support, or master.

When connector is published from a branch different to a release branch, the suffix -dev will be added to the version.