### PR TITLE
Change the CDN path for OpenLayers HTML dependency

### DIFF
--- a/examples/nodejs/web_socket/indexMaps.html
+++ b/examples/nodejs/web_socket/indexMaps.html
@@ -13,7 +13,7 @@
     <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
     <script src="/socket.io/socket.io.js"></script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-    <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/main/dist/en/v6.0.1/build/ol.js"></script>
+    <script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/main/dist/en/v6.15.1/build/ol.js"></script>
     <style>
       .map {
         width: 100%;


### PR DESCRIPTION
As it happened in the past (see #185), the CDN for the Maps Example stopped working for some reason.
For this reason, I've bumped up the version of OpenLayers CDN package from 6.0.1 to 6.15.1, which is available in the same CDN.