### PR TITLE
Add CON-307 to release notes for release 1.3.2

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,6 +32,27 @@ macOS® platforms. It has been tested on the following systems:
 `the main Connector
 repository <https://github.com/rticommunity/rticonnextdds-connector>`__.
 
+Version 1.3.2
+=============
+
+What's New in 1.3.2
+-------------------
+
+Potential errors on copying strings when using JSON
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. CON-307
+
+*Connector* did not check the return value of ``snprintf``, which could 
+fail in scenarios where, for example, the input buffer was not big enough. 
+This issue affected code related to:
+
+* Getting JSON list of matched publication names
+
+* Getting JSON list of matched subscription names
+
+* Getting JSON representation of sample identity
+
+
 Version 1.3.1
 =============
 


### PR DESCRIPTION
Added CON-307 to 1.3.2 release notes. 
[Doc output](https://jenkins-community.rti.com/job/ci/job/connector/job/js/job/doc/view/change-requests/job/PR-252/Connector_20Documentation/)