### PR TITLE
CON-379: Remove EOL node releases from Release Notes

### DIFF
--- a/ci_config.yaml
+++ b/ci_config.yaml
@@ -1,6 +1,6 @@
 node_versions:
-  - "18"
-  - "19"
+  - "18" # Kept for CI, but ignored in release notes
+  - "19" # ^
   - "20"
   - "22"
   - "24"

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,8 +5,6 @@ Supported Platforms
 ===================
 
 *Connector* has been validated to run with the following Node.js versions:
-  * v18
-  * v19
   * v20
   * v22
   * v24


### PR DESCRIPTION
Node 18 and Node 19 are considered EOL by Node's Security Support as seen [here](https://endoflife.date/nodejs). As a consequence, we're removing their mention from the release notes.