### PR TITLE
REL-4813 -- version string changes for connextdds 7.3.1.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ copyright = '2019-2025, Real-Time Innovations, Inc'
 author = 'Real-Time Innovations, Inc.'
 
 # The full version, including alpha/beta/rc tags
-release = '1.3.2'
-version = '1.3.2'
+release = '1.3.3'
+version = '1.3.3'
 
 master_doc = 'index'
 primary_domain = 'js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "rticonnextdds-connector",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "SEE LICENSE IN LICENSE.pdf",
       "dependencies": {
         "events": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rticonnextdds-connector",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "RTI Connector for JavaScript",
   "main": "rticonnextdds-connector.js",
   "files": [


### PR DESCRIPTION
These string changes are required for the upcoming 7.3.1.1 connextdds patch. The next version of rticonnextdds-connector-js will be 1.3.3